### PR TITLE
[BUG] : cors origin 주소 명시

### DIFF
--- a/backend/src/main/java/z9/hobby/global/config/SecurityConfig.kt
+++ b/backend/src/main/java/z9/hobby/global/config/SecurityConfig.kt
@@ -42,7 +42,7 @@ class SecurityConfig(
     fun corsConfigurationSource(): CorsConfigurationSource {
         val configuration = CorsConfiguration()
         configuration.allowCredentials = true
-        configuration.allowedOrigins = listOf("*")
+        configuration.allowedOrigins = listOf("http://localhost:3000")
         configuration.allowedMethods = listOf("*")
         configuration.allowedHeaders = listOf(ACCESS_TOKEN_HEADER, CONTENT_TYPE)
         configuration.exposedHeaders = listOf(ACCESS_TOKEN_HEADER)


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#28 
  <br/>

## 🔎 작업 내용
- 기존에 * 로 전부 허용 해줬으나, allowCredentails 을 true 로 설정 시, * 이 작동되지 않음.
- 출처 [링크](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html?utm_source=chatgpt.com#setAllowedOrigins(java.util.List)

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>