### PR TITLE
[FEAT]: 일정 추가, 생성할 때 주소 정보 추가 기능 구현

### DIFF
--- a/backend/src/main/java/z9/hobby/domain/schedules/controller/SchedulesController.kt
+++ b/backend/src/main/java/z9/hobby/domain/schedules/controller/SchedulesController.kt
@@ -23,7 +23,10 @@ class SchedulesController(
     private val schedulesService: SchedulesService
 ) {
     @PostMapping("/classes")
-    @Operation(summary = "모임 일정 생성", description = "새로운 모임 일정을 생성합니다. 모임장만 생성 가능합니다.")
+    @Operation(
+        summary = "모임 일정 생성",
+        description = "새로운 모임 일정을 생성합니다. 모임장만 생성 가능합니다. 필요시 모임 장소와 위도/경도 정보를 함께 저장합니다."
+    )
     fun create(
         @RequestBody @Valid requestData: CreateRequest,
         principal: Principal
@@ -34,7 +37,10 @@ class SchedulesController(
     }
 
     @PutMapping("/{scheduleId}/classes/{classId}")
-    @Operation(summary = "모임 일정 수정", description = "모임의 일정을 수정합니다.")
+    @Operation(
+        summary = "모임 일정 수정",
+        description = "모임의 일정을 수정합니다. 모임 장소와 위도/경도 정보도 수정 가능합니다."
+    )
     fun modify(
         @Parameter(description = "일정 ID", required = true) @PathVariable scheduleId: Long,
         @Parameter(description = "모임 ID", required = true) @PathVariable classId: Long,

--- a/backend/src/main/java/z9/hobby/domain/schedules/dto/SchedulesRequestDto.kt
+++ b/backend/src/main/java/z9/hobby/domain/schedules/dto/SchedulesRequestDto.kt
@@ -26,7 +26,25 @@ class SchedulesRequestDto {
             regexp = "^[\\p{L}\\p{N}\\s,.!?()-]+$",
             message = "모임 제목에는 문자, 숫자, 기본 특수문자만 사용할 수 있습니다"
         )
-        val meetingTitle: String? = null
+        val meetingTitle: String? = null,
+
+        @field:NotNull(message = "meeting_place must not be null")
+        @field:Size(
+            min = 1,
+            max = 100,
+            message = "모임 장소는 1글자 이상 100자 이하이어야 합니다."
+        )
+        @field:Pattern(
+            regexp = "^[\\p{L}\\p{N}\\s,.!?()-]+$",
+            message = "모임 장소에는 문자, 숫자, 기본 특수문자만 사용할 수 있습니다"
+        )
+        val meetingPlace: String? = null,
+
+        @field:NotNull(message = "latitude must not be null")
+        val latitude: Double? = null,
+
+        @field:NotNull(message = "longitude must not be null")
+        val longitude: Double? = null
     ) {
         companion object {
             @JvmStatic
@@ -37,15 +55,24 @@ class SchedulesRequestDto {
             private var classId: Long? = null
             private var meetingTime: String? = null
             private var meetingTitle: String? = null
+            private var meetingPlace: String? = null
+            private var latitude: Double? = null
+            private var longitude: Double? = null
 
             fun classId(classId: Long?) = apply { this.classId = classId }
             fun meetingTime(meetingTime: String?) = apply { this.meetingTime = meetingTime }
             fun meetingTitle(meetingTitle: String?) = apply { this.meetingTitle = meetingTitle }
+            fun meetingPlace(meetingPlace: String?) = apply { this.meetingPlace = meetingPlace }
+            fun latitude(latitude: Double?) = apply { this.latitude = latitude }
+            fun longitude(longitude: Double?) = apply { this.longitude = longitude }
 
             fun build() = CreateRequest(
                 classId = classId,
                 meetingTime = meetingTime,
-                meetingTitle = meetingTitle
+                meetingTitle = meetingTitle,
+                meetingPlace = meetingPlace,
+                latitude = latitude,
+                longitude = longitude
             )
         }
     }
@@ -69,7 +96,25 @@ class SchedulesRequestDto {
             regexp = "^[\\p{L}\\p{N}\\s,.!?()-]+$",
             message = "모임 제목에는 문자, 숫자, 기본 특수문자만 사용할 수 있습니다"
         )
-        val meetingTitle: String? = null
+        val meetingTitle: String? = null,
+
+        @field:NotNull(message = "meeting_place must not be null")
+        @field:Size(
+            min = 1,
+            max = 100,
+            message = "모임 장소는 1글자 이상 100자 이하이어야 합니다."
+        )
+        @field:Pattern(
+            regexp = "^[\\p{L}\\p{N}\\s,.!?()-]+$",
+            message = "모임 장소에는 문자, 숫자, 기본 특수문자만 사용할 수 있습니다"
+        )
+        val meetingPlace: String? = null,
+
+        @field:NotNull(message = "latitude must not be null")
+        val latitude: Double? = null,
+
+        @field:NotNull(message = "longitude must not be null")
+        val longitude: Double? = null
     ) {
         companion object {
             @JvmStatic
@@ -79,13 +124,22 @@ class SchedulesRequestDto {
         class Builder {
             private var meetingTime: String? = null
             private var meetingTitle: String? = null
+            private var meetingPlace: String? = null
+            private var latitude: Double? = null
+            private var longitude: Double? = null
 
             fun meetingTime(meetingTime: String?) = apply { this.meetingTime = meetingTime }
             fun meetingTitle(meetingTitle: String?) = apply { this.meetingTitle = meetingTitle }
+            fun meetingPlace(meetingPlace: String?) = apply { this.meetingPlace = meetingPlace }
+            fun latitude(latitude: Double?) = apply { this.latitude = latitude }
+            fun longitude(longitude: Double?) = apply { this.longitude = longitude }
 
             fun build() = UpdateRequest(
                 meetingTime = meetingTime,
-                meetingTitle = meetingTitle
+                meetingTitle = meetingTitle,
+                meetingPlace = meetingPlace,
+                latitude = latitude,
+                longitude = longitude
             )
         }
     }

--- a/backend/src/main/java/z9/hobby/domain/schedules/dto/SchedulesRequestDto.kt
+++ b/backend/src/main/java/z9/hobby/domain/schedules/dto/SchedulesRequestDto.kt
@@ -41,10 +41,10 @@ class SchedulesRequestDto {
         val meetingPlace: String? = null,
 
         @field:NotNull(message = "latitude must not be null")
-        val latitude: Double? = null,
+        val lat: Double? = null,
 
         @field:NotNull(message = "longitude must not be null")
-        val longitude: Double? = null
+        val lng: Double? = null
     ) {
         companion object {
             @JvmStatic
@@ -56,23 +56,23 @@ class SchedulesRequestDto {
             private var meetingTime: String? = null
             private var meetingTitle: String? = null
             private var meetingPlace: String? = null
-            private var latitude: Double? = null
-            private var longitude: Double? = null
+            private var lat: Double? = null
+            private var lng: Double? = null
 
             fun classId(classId: Long?) = apply { this.classId = classId }
             fun meetingTime(meetingTime: String?) = apply { this.meetingTime = meetingTime }
             fun meetingTitle(meetingTitle: String?) = apply { this.meetingTitle = meetingTitle }
             fun meetingPlace(meetingPlace: String?) = apply { this.meetingPlace = meetingPlace }
-            fun latitude(latitude: Double?) = apply { this.latitude = latitude }
-            fun longitude(longitude: Double?) = apply { this.longitude = longitude }
+            fun lat(lat: Double?) = apply { this.lat = lat }
+            fun lng(lng: Double?) = apply { this.lng = lng }
 
             fun build() = CreateRequest(
                 classId = classId,
                 meetingTime = meetingTime,
                 meetingTitle = meetingTitle,
                 meetingPlace = meetingPlace,
-                latitude = latitude,
-                longitude = longitude
+                lat = lat,
+                lng = lng
             )
         }
     }
@@ -111,10 +111,10 @@ class SchedulesRequestDto {
         val meetingPlace: String? = null,
 
         @field:NotNull(message = "latitude must not be null")
-        val latitude: Double? = null,
+        val lat: Double? = null,
 
         @field:NotNull(message = "longitude must not be null")
-        val longitude: Double? = null
+        val lng: Double? = null
     ) {
         companion object {
             @JvmStatic
@@ -125,21 +125,21 @@ class SchedulesRequestDto {
             private var meetingTime: String? = null
             private var meetingTitle: String? = null
             private var meetingPlace: String? = null
-            private var latitude: Double? = null
-            private var longitude: Double? = null
+            private var lat: Double? = null
+            private var lng: Double? = null
 
             fun meetingTime(meetingTime: String?) = apply { this.meetingTime = meetingTime }
             fun meetingTitle(meetingTitle: String?) = apply { this.meetingTitle = meetingTitle }
             fun meetingPlace(meetingPlace: String?) = apply { this.meetingPlace = meetingPlace }
-            fun latitude(latitude: Double?) = apply { this.latitude = latitude }
-            fun longitude(longitude: Double?) = apply { this.longitude = longitude }
+            fun lat(lat: Double?) = apply { this.lat = lat }
+            fun lng(lng: Double?) = apply { this.lng = lng }
 
             fun build() = UpdateRequest(
                 meetingTime = meetingTime,
                 meetingTitle = meetingTitle,
                 meetingPlace = meetingPlace,
-                latitude = latitude,
-                longitude = longitude
+                lat = lat,
+                lng = lng
             )
         }
     }

--- a/backend/src/main/java/z9/hobby/domain/schedules/dto/SchedulesResponseDto.kt
+++ b/backend/src/main/java/z9/hobby/domain/schedules/dto/SchedulesResponseDto.kt
@@ -6,7 +6,10 @@ class SchedulesResponseDto {
     data class ResponseData(
         val scheduleId: Long? = null, // 생성된 일정의 ID
         val meetingTime: String? = null, // 모임 시간
-        val meetingTitle: String? = null // 모임 제목
+        val meetingTitle: String? = null, // 모임 제목
+        val meetingPlace: String? = null, // 모임 장소
+        val latitude: Double? = null, // 모임 위치 경도, 위도
+        val longitude: Double? = null
     ) {
         companion object {
             @JvmStatic
@@ -14,7 +17,10 @@ class SchedulesResponseDto {
                 return ResponseData(
                     scheduleId = schedulesEntity.getId(),
                     meetingTime = schedulesEntity.getMeetingTime(),
-                    meetingTitle = schedulesEntity.getMeetingTitle()
+                    meetingTitle = schedulesEntity.getMeetingTitle(),
+                    meetingPlace = schedulesEntity.getMeetingPlace(),
+                    latitude = schedulesEntity.getLatitude(),
+                    longitude = schedulesEntity.getLongitude()
                 )
             }
         }

--- a/backend/src/main/java/z9/hobby/domain/schedules/dto/SchedulesResponseDto.kt
+++ b/backend/src/main/java/z9/hobby/domain/schedules/dto/SchedulesResponseDto.kt
@@ -8,8 +8,8 @@ class SchedulesResponseDto {
         val meetingTime: String? = null, // 모임 시간
         val meetingTitle: String? = null, // 모임 제목
         val meetingPlace: String? = null, // 모임 장소
-        val latitude: Double? = null, // 모임 위치 경도, 위도
-        val longitude: Double? = null
+        val lat: Double? = null, // 모임 위치 경도, 위도
+        val lng: Double? = null
     ) {
         companion object {
             @JvmStatic
@@ -19,8 +19,8 @@ class SchedulesResponseDto {
                     meetingTime = schedulesEntity.getMeetingTime(),
                     meetingTitle = schedulesEntity.getMeetingTitle(),
                     meetingPlace = schedulesEntity.getMeetingPlace(),
-                    latitude = schedulesEntity.getLatitude(),
-                    longitude = schedulesEntity.getLongitude()
+                    lat = schedulesEntity.getLat(),
+                    lng = schedulesEntity.getLng()
                 )
             }
         }

--- a/backend/src/main/java/z9/hobby/domain/schedules/service/SchedulesService.kt
+++ b/backend/src/main/java/z9/hobby/domain/schedules/service/SchedulesService.kt
@@ -26,7 +26,7 @@ class SchedulesService(
     //생성
     @Transactional
     fun create(requestData: CreateRequest, userId: Long): SchedulesResponseDto.ResponseData {
-        if (requestData.meetingTime.isNullOrBlank() || requestData.meetingTitle.isNullOrBlank()) {
+        if (requestData.meetingTime.isNullOrBlank() || requestData.meetingTitle.isNullOrBlank() || requestData.meetingPlace.isNullOrBlank()) {
             throw CustomException(ErrorCode.SCHEDULE_CREATE_FAILED)
         }
 
@@ -56,6 +56,9 @@ class SchedulesService(
                 .classes(classes)
                 .meetingTime(requestData.meetingTime)
                 .meetingTitle(requestData.meetingTitle)
+                .meetingPlace(requestData.meetingPlace)
+                .latitude(requestData.latitude)
+                .longitude(requestData.longitude)
                 .build()
 
             // DB에 저장
@@ -80,7 +83,7 @@ class SchedulesService(
         requestData: UpdateRequest,
         userId: Long?
     ): SchedulesResponseDto.ResponseData {
-        if (requestData.meetingTime.isNullOrBlank() || requestData.meetingTitle.isNullOrBlank()) {
+        if (requestData.meetingTime.isNullOrBlank() || requestData.meetingTitle.isNullOrBlank() || requestData.meetingPlace.isNullOrBlank()) {
             throw CustomException(ErrorCode.SCHEDULE_UPDATE_FAILED)
         }
 
@@ -106,7 +109,7 @@ class SchedulesService(
             }
 
             // 일정 정보 업데이트
-            schedule.updateSchedule(requestData.meetingTime, requestData.meetingTitle)
+            schedule.updateSchedule(requestData.meetingTime, requestData.meetingTitle, requestData.meetingPlace, requestData.latitude, requestData.longitude)
             // DB에 저장
             val savedSchedule = schedulesRepository.save(schedule)
 

--- a/backend/src/main/java/z9/hobby/domain/schedules/service/SchedulesService.kt
+++ b/backend/src/main/java/z9/hobby/domain/schedules/service/SchedulesService.kt
@@ -26,7 +26,11 @@ class SchedulesService(
     //생성
     @Transactional
     fun create(requestData: CreateRequest, userId: Long): SchedulesResponseDto.ResponseData {
-        if (requestData.meetingTime.isNullOrBlank() || requestData.meetingTitle.isNullOrBlank() || requestData.meetingPlace.isNullOrBlank()) {
+        if (requestData.meetingTime.isNullOrBlank() ||
+            requestData.meetingTitle.isNullOrBlank() ||
+            requestData.meetingPlace.isNullOrBlank() ||
+            requestData.lat == null ||
+            requestData.lng == null) {
             throw CustomException(ErrorCode.SCHEDULE_CREATE_FAILED)
         }
 
@@ -57,8 +61,8 @@ class SchedulesService(
                 .meetingTime(requestData.meetingTime)
                 .meetingTitle(requestData.meetingTitle)
                 .meetingPlace(requestData.meetingPlace)
-                .latitude(requestData.latitude)
-                .longitude(requestData.longitude)
+                .lat(requestData.lat)
+                .lng(requestData.lng)
                 .build()
 
             // DB에 저장
@@ -83,7 +87,11 @@ class SchedulesService(
         requestData: UpdateRequest,
         userId: Long?
     ): SchedulesResponseDto.ResponseData {
-        if (requestData.meetingTime.isNullOrBlank() || requestData.meetingTitle.isNullOrBlank() || requestData.meetingPlace.isNullOrBlank()) {
+        if (requestData.meetingTime.isNullOrBlank() ||
+            requestData.meetingTitle.isNullOrBlank() ||
+            requestData.meetingPlace.isNullOrBlank() ||
+            requestData.lat == null ||
+            requestData.lng == null) {
             throw CustomException(ErrorCode.SCHEDULE_UPDATE_FAILED)
         }
 
@@ -109,7 +117,7 @@ class SchedulesService(
             }
 
             // 일정 정보 업데이트
-            schedule.updateSchedule(requestData.meetingTime, requestData.meetingTitle, requestData.meetingPlace, requestData.latitude, requestData.longitude)
+            schedule.updateSchedule(requestData.meetingTime, requestData.meetingTitle, requestData.meetingPlace, requestData.lat, requestData.lng)
             // DB에 저장
             val savedSchedule = schedulesRepository.save(schedule)
 

--- a/backend/src/main/java/z9/hobby/global/config/SecurityConfig.kt
+++ b/backend/src/main/java/z9/hobby/global/config/SecurityConfig.kt
@@ -42,7 +42,7 @@ class SecurityConfig(
     fun corsConfigurationSource(): CorsConfigurationSource {
         val configuration = CorsConfiguration()
         configuration.allowCredentials = true
-        configuration.allowedOrigins = listOf("*")
+        configuration.allowedOrigins = listOf("http://localhost:3000")
         configuration.allowedMethods = listOf("*")
         configuration.allowedHeaders = listOf(ACCESS_TOKEN_HEADER, CONTENT_TYPE)
         configuration.exposedHeaders = listOf(ACCESS_TOKEN_HEADER)

--- a/backend/src/main/java/z9/hobby/global/initdata/BaseInitData.java
+++ b/backend/src/main/java/z9/hobby/global/initdata/BaseInitData.java
@@ -159,6 +159,9 @@ public class BaseInitData {
                         .classes(classEntity)
                         .meetingTime(meetingTime)
                         .meetingTitle("모임 " + classEntity.getId() + "의 " + i + "번째 일정")
+                        .meetingPlace("서울특별시 강남구 테헤란로 " + (i * 10) + "길") // 기본 장소 추가
+                        .lat(37.5665 + (i * 0.001)) // 서울 중심부 좌표에 약간의 변화를 줌
+                        .lng(126.9780 + (i * 0.001)) // 서울 중심부 좌표에 약간의 변화를 줌
                         .build();
                 schedulesRepository.save(schedule);
             }

--- a/backend/src/main/java/z9/hobby/model/schedules/SchedulesEntity.kt
+++ b/backend/src/main/java/z9/hobby/model/schedules/SchedulesEntity.kt
@@ -23,6 +23,15 @@ class SchedulesEntity(
     @Column(name = "meeting_title", nullable = false)
     private var meetingTitle: String? = null,
 
+    @Column(name = "meeting_place", nullable = false)
+    private var meetingPlace: String? = null,
+
+    @Column(name = "latitude", nullable = false)
+    private var latitude: Double? = null,
+
+    @Column(name = "longitude", nullable = false)
+    private var longitude: Double? = null,
+
     @OneToMany(mappedBy = "schedules", cascade = [CascadeType.ALL], orphanRemoval = true)
     private var checkins: MutableList<CheckInEntity> = mutableListOf()
 ) : BaseEntity() {
@@ -31,11 +40,17 @@ class SchedulesEntity(
     fun getClasses(): ClassEntity = classes ?: throw IllegalStateException("Classes should not be null")
     fun getMeetingTime(): String? = meetingTime
     fun getMeetingTitle(): String? = meetingTitle
+    fun getMeetingPlace(): String? = meetingPlace
+    fun getLatitude(): Double? = latitude
+    fun getLongitude(): Double? = longitude
     fun getCheckins(): List<CheckInEntity> = checkins
 
-    fun updateSchedule(meetingTime: String?, meetingTitle: String?) {
+    fun updateSchedule(meetingTime: String?, meetingTitle: String?, meetingPlace: String?, latitude: Double?, longitude: Double?) {
         this.meetingTime = meetingTime
         this.meetingTitle = meetingTitle
+        this.meetingPlace = meetingPlace
+        this.latitude = latitude
+        this.longitude = longitude
     }
     // Builder pattern implementation in Kotlin
     companion object {
@@ -48,12 +63,18 @@ class SchedulesEntity(
         private var classes: ClassEntity? = null
         private var meetingTime: String? = null
         private var meetingTitle: String? = null
+        private var meetingPlace: String? = null
+        private var latitude: Double? = null
+        private var longitude: Double? = null
         private var checkins: MutableList<CheckInEntity> = mutableListOf()
 
         fun id(id: Long?) = apply { this.id = id }
         fun classes(classes: ClassEntity?) = apply { this.classes = classes }
         fun meetingTime(meetingTime: String?) = apply { this.meetingTime = meetingTime }
         fun meetingTitle(meetingTitle: String?) = apply { this.meetingTitle = meetingTitle }
+        fun meetingPlace(meetingPlace: String?) = apply { this.meetingPlace = meetingPlace }
+        fun latitude(latitude: Double?) = apply { this.latitude = latitude }
+        fun longitude(longitude: Double?) = apply { this.longitude = longitude }
         fun checkins(checkins: List<CheckInEntity>) = apply { this.checkins.addAll(checkins) }
 
         fun build() = SchedulesEntity(
@@ -61,6 +82,9 @@ class SchedulesEntity(
             classes = classes,
             meetingTime = meetingTime,
             meetingTitle = meetingTitle,
+            meetingPlace = meetingPlace,
+            latitude = latitude,
+            longitude = longitude,
             checkins = checkins
         )
     }

--- a/backend/src/main/java/z9/hobby/model/schedules/SchedulesEntity.kt
+++ b/backend/src/main/java/z9/hobby/model/schedules/SchedulesEntity.kt
@@ -26,11 +26,11 @@ class SchedulesEntity(
     @Column(name = "meeting_place", nullable = false)
     private var meetingPlace: String? = null,
 
-    @Column(name = "latitude", nullable = false)
-    private var latitude: Double? = null,
+    @Column(name = "lat", nullable = false)
+    private var lat: Double? = null,
 
-    @Column(name = "longitude", nullable = false)
-    private var longitude: Double? = null,
+    @Column(name = "lng", nullable = false)
+    private var lng: Double? = null,
 
     @OneToMany(mappedBy = "schedules", cascade = [CascadeType.ALL], orphanRemoval = true)
     private var checkins: MutableList<CheckInEntity> = mutableListOf()
@@ -41,16 +41,16 @@ class SchedulesEntity(
     fun getMeetingTime(): String? = meetingTime
     fun getMeetingTitle(): String? = meetingTitle
     fun getMeetingPlace(): String? = meetingPlace
-    fun getLatitude(): Double? = latitude
-    fun getLongitude(): Double? = longitude
+    fun getLat(): Double? = lat
+    fun getLng(): Double? = lng
     fun getCheckins(): List<CheckInEntity> = checkins
 
-    fun updateSchedule(meetingTime: String?, meetingTitle: String?, meetingPlace: String?, latitude: Double?, longitude: Double?) {
+    fun updateSchedule(meetingTime: String?, meetingTitle: String?, meetingPlace: String?, lat: Double?, lng: Double?) {
         this.meetingTime = meetingTime
         this.meetingTitle = meetingTitle
         this.meetingPlace = meetingPlace
-        this.latitude = latitude
-        this.longitude = longitude
+        this.lat = lat
+        this.lng = lng
     }
     // Builder pattern implementation in Kotlin
     companion object {
@@ -64,8 +64,8 @@ class SchedulesEntity(
         private var meetingTime: String? = null
         private var meetingTitle: String? = null
         private var meetingPlace: String? = null
-        private var latitude: Double? = null
-        private var longitude: Double? = null
+        private var lat: Double? = null
+        private var lng: Double? = null
         private var checkins: MutableList<CheckInEntity> = mutableListOf()
 
         fun id(id: Long?) = apply { this.id = id }
@@ -73,8 +73,8 @@ class SchedulesEntity(
         fun meetingTime(meetingTime: String?) = apply { this.meetingTime = meetingTime }
         fun meetingTitle(meetingTitle: String?) = apply { this.meetingTitle = meetingTitle }
         fun meetingPlace(meetingPlace: String?) = apply { this.meetingPlace = meetingPlace }
-        fun latitude(latitude: Double?) = apply { this.latitude = latitude }
-        fun longitude(longitude: Double?) = apply { this.longitude = longitude }
+        fun lat(lat: Double?) = apply { this.lat = lat }
+        fun lng(lng: Double?) = apply { this.lng = lng }
         fun checkins(checkins: List<CheckInEntity>) = apply { this.checkins.addAll(checkins) }
 
         fun build() = SchedulesEntity(
@@ -83,8 +83,8 @@ class SchedulesEntity(
             meetingTime = meetingTime,
             meetingTitle = meetingTitle,
             meetingPlace = meetingPlace,
-            latitude = latitude,
-            longitude = longitude,
+            lat = lat,
+            lng = lng,
             checkins = checkins
         )
     }

--- a/backend/src/main/resources/config/application-dev_db.yml
+++ b/backend/src/main/resources/config/application-dev_db.yml
@@ -6,7 +6,7 @@ spring:
     password: ${Z9_DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create
       naming:
         physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
     properties:

--- a/backend/src/test/java/z9/hobby/domain/schedules/base/SchedulesBaseTest.java
+++ b/backend/src/test/java/z9/hobby/domain/schedules/base/SchedulesBaseTest.java
@@ -49,6 +49,9 @@ public abstract class SchedulesBaseTest extends SpringBootTestSupporter {
                 .classes(classEntity)
                 .meetingTime(getTestMeetingTime())
                 .meetingTitle(SchedulesBaseTest.TEST_MEETING_TITLE)
+                .meetingPlace("테스트 장소")
+                .lat(37.5665)
+                .lng(126.9780)
                 .build());
     }
 
@@ -69,6 +72,9 @@ public abstract class SchedulesBaseTest extends SpringBootTestSupporter {
                 .classId(classId)
                 .meetingTime(getTestMeetingTime())
                 .meetingTitle(TEST_MEETING_TITLE)
+                .meetingPlace("테스트 장소")
+                .lat(37.5665)
+                .lng(126.9780)
                 .build();
     }
 }

--- a/backend/src/test/java/z9/hobby/domain/schedules/controller/SchedulesControllerTest.java
+++ b/backend/src/test/java/z9/hobby/domain/schedules/controller/SchedulesControllerTest.java
@@ -85,6 +85,9 @@ class SchedulesControllerTest extends SchedulesBaseTest {
                 .classId(classEntity.getId())
                 .meetingTime("2025-02-05") // 잘못된 형식
                 .meetingTitle("테") // 2글자 미만
+                .meetingPlace("테스트 장소")
+                .lat(37.5665)
+                .lng(126.9780)
                 .build();
 
         // when
@@ -195,6 +198,9 @@ class SchedulesControllerTest extends SchedulesBaseTest {
         SchedulesRequestDto.UpdateRequest updateRequest = SchedulesRequestDto.UpdateRequest.builder()
                 .meetingTime(getTestMeetingTime())
                 .meetingTitle("수정된 테스트 일정")
+                .meetingPlace("수정된 테스트 장소")
+                .lat(37.5665)
+                .lng(126.9780)
                 .build();
 
         // when
@@ -221,6 +227,9 @@ class SchedulesControllerTest extends SchedulesBaseTest {
         SchedulesRequestDto.UpdateRequest updateRequest = SchedulesRequestDto.UpdateRequest.builder()
                 .meetingTime(getTestMeetingTime())
                 .meetingTitle("수정된 테스트 일정")
+                .meetingPlace("수정된 테스트 장소")
+                .lat(37.5665)
+                .lng(126.9780)
                 .build();
 
         // when

--- a/backend/src/test/java/z9/hobby/domain/schedules/service/SchedulesServiceTest.java
+++ b/backend/src/test/java/z9/hobby/domain/schedules/service/SchedulesServiceTest.java
@@ -74,6 +74,9 @@ class SchedulesServiceTest extends SchedulesBaseTest {
                 .classId(999L)
                 .meetingTime(futureDate)  // 현재 날짜 + 7일
                 .meetingTitle("테스트 일정")
+                .meetingPlace("테스트 장소")
+                .lat(37.5665)
+                .lng(126.9780)
                 .build();
 
         // when & then
@@ -164,6 +167,9 @@ class SchedulesServiceTest extends SchedulesBaseTest {
         SchedulesRequestDto.UpdateRequest updateRequest = SchedulesRequestDto.UpdateRequest.builder()
                 .meetingTime(newMeetingTime)
                 .meetingTitle("수정된 테스트 일정")
+                .meetingPlace("수정된 테스트 장소")
+                .lat(37.5665)
+                .lng(126.9780)
                 .build();
 
         // when
@@ -189,6 +195,9 @@ class SchedulesServiceTest extends SchedulesBaseTest {
         SchedulesRequestDto.UpdateRequest updateRequest = SchedulesRequestDto.UpdateRequest.builder()
                 .meetingTime(getTestMeetingTime())
                 .meetingTitle("수정된 테스트 일정")
+                .meetingPlace("수정된 테스트 장소")
+                .lat(37.5665)
+                .lng(126.9780)
                 .build();
 
         // when & then
@@ -208,6 +217,9 @@ class SchedulesServiceTest extends SchedulesBaseTest {
         SchedulesRequestDto.UpdateRequest updateRequest = SchedulesRequestDto.UpdateRequest.builder()
                 .meetingTime(getTestMeetingTime())
                 .meetingTitle("수정된 테스트 일정")
+                .meetingPlace("수정된 테스트 장소")
+                .lat(37.5665)
+                .lng(126.9780)
                 .build();
 
         // when & then

--- a/backend/src/test/java/z9/hobby/domain/search/controller/SearchControllerTest.java
+++ b/backend/src/test/java/z9/hobby/domain/search/controller/SearchControllerTest.java
@@ -36,6 +36,14 @@ class SearchControllerTest extends SearchBaseTest {
 
         // 4. 테스트 모임 생성
         class1 = createTestClass(user.getId(), "운동");
+
+        // 5. 시간 차이 생성
+        try {
+            Thread.sleep(100); // 100ms 대기
+        } catch (InterruptedException e) {
+            // 무시
+        }
+
         class2 = createTestClass(user.getId(), "음악");
     }
 

--- a/backend/src/test/java/z9/hobby/integration/factory/SchedulesFactory.java
+++ b/backend/src/test/java/z9/hobby/integration/factory/SchedulesFactory.java
@@ -34,6 +34,9 @@ public class SchedulesFactory {
                     .classes(classEntity)
                     .meetingTime(formattedTime)
                     .meetingTitle(meetingTitle)
+                    .meetingPlace(String.format("테스트 장소 %d", index))
+                    .lat(37.5665 + (index * 0.001))  // 서울 중심부 위도
+                    .lng(126.9780 + (index * 0.001))  // 서울 중심부 경도
                     .build();
             SchedulesEntity saveSchedule = schedulesRepository.save(newSchedule);
             saveScheduleList.add(saveSchedule);

--- a/frontend/src/components/address/Address.jsx
+++ b/frontend/src/components/address/Address.jsx
@@ -1,13 +1,20 @@
 import './Address.css';
 import React, { useEffect, useState } from 'react';
 
-const Address = ({ onAddressSelect }) => {
+const Address = ({ onAddressSelect, initialAddress, initialLat, initialLng }) => {
     const [postcode, setPostcode] = useState("");
     const [address, setAddress] = useState("");
     const [detailAddress, setDetailAddress] = useState("");
     const [extraAddress, setExtraAddress] = useState("");
     const [lat, setLat] = useState("");
     const [lng, setLng] = useState("");
+
+    // 초기값이 변경될 때 상태 업데이트
+    useEffect(() => {
+        if (initialAddress) setAddress(initialAddress);
+        if (initialLat) setLat(initialLat);
+        if (initialLng) setLng(initialLng);
+    }, [initialAddress, initialLat, initialLng]);
 
     useEffect(() => {
         const script = document.createElement('script');

--- a/frontend/src/components/customList/CustomList.jsx
+++ b/frontend/src/components/customList/CustomList.jsx
@@ -8,6 +8,7 @@ const CustomList = forwardRef(
             data2,
             data3,
             data4,
+            data5,
             check,
             title = "",
             description = "",
@@ -26,6 +27,7 @@ const CustomList = forwardRef(
                 <div className="item-info">
                     <h4 className="name">{data2}</h4>
                     {description && <p className="description">{data3}</p>}
+                    {data5 && <p className="place">장소: {data5}</p>}
                     {sub && <span className="date">{data4}</span>}
                 </div>
                 <div className="buttons">

--- a/frontend/src/pages/class/[id]/Class.jsx
+++ b/frontend/src/pages/class/[id]/Class.jsx
@@ -153,7 +153,7 @@ const Class = () => {
       classId: id,
       meetingTime: meetingTime,
       meetingTitle: meetingTitle,
-      address: `${addressInfo.address} ${addressInfo.detailAddress}`,
+      meetingPlace: `${addressInfo.address} ${addressInfo.detailAddress}`,
       lat: addressInfo.lat,
       lng: addressInfo.lng
     };
@@ -255,6 +255,7 @@ const Class = () => {
                   data1={schedule?.scheduleId}
                   data2={schedule?.meetingTitle}
                   data3={schedule?.meetingTime}
+                  data5={schedule?.meetingPlace}
                   description="true"
                   button1 ="참석"
                   onClick1={()=>debouncedHandleCheckIn(schedule?.scheduleId,true)}

--- a/frontend/src/pages/class/[id]/Class.jsx
+++ b/frontend/src/pages/class/[id]/Class.jsx
@@ -149,13 +149,27 @@ const Class = () => {
       return;
     }
 
+    // 주소 검증
+    if (!addressInfo.address) {
+      Alert("모임 장소를 입력해주세요.");
+      return;
+    }
+
+    // 좌표 검증
+    if (!addressInfo.lat || !addressInfo.lng ||
+        isNaN(parseFloat(addressInfo.lat)) ||
+        isNaN(parseFloat(addressInfo.lng))) {
+      Alert("유효한 위치 정보가 필요합니다. 주소를 다시 검색해주세요.");
+      return;
+    }
+
     const body = {
       classId: id,
       meetingTime: meetingTime,
       meetingTitle: meetingTitle,
       meetingPlace: `${addressInfo.address} ${addressInfo.detailAddress}`,
-      lat: addressInfo.lat,
-      lng: addressInfo.lng
+      lat: parseFloat(addressInfo.lat),  // 명시적 변환
+      lng: parseFloat(addressInfo.lng)   // 명시적 변환
     };
     try {
       const response = await ScheduleService.postSchedulesLists(body);
@@ -252,6 +266,7 @@ const Class = () => {
           <h3>일정 목록</h3>
           {schedules.length > 0 && schedules.map((schedule) => (
               <CustomList
+                  key={schedule?.scheduleId}
                   data1={schedule?.scheduleId}
                   data2={schedule?.meetingTitle}
                   data3={schedule?.meetingTime}

--- a/frontend/src/pages/schedules/[id]/ScheduleDetail.jsx
+++ b/frontend/src/pages/schedules/[id]/ScheduleDetail.jsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { ScheduleService } from '../../../services/SheduleService';
 import Alert from '../../../components/alert/Alert';
 import DateTimeInput from '../../../components/dateTimeInput/DateTimeInput';
+import Address from "../../../components/address/Address";
 import './ScheduleDetail.css';
 
 const ScheduleDetail = () => {
@@ -12,14 +13,44 @@ const ScheduleDetail = () => {
     const [isEditing, setIsEditing] = useState(false);
     const [meetingTitle, setMeetingTitle] = useState('');
     const [meetingTime, setMeetingTime] = useState('');
+    const [addressInfo, setAddressInfo] = useState({
+        address: '',
+        detailAddress: '',
+        extraAddress: '',
+        postcode: '',
+        lat: '',
+        lng: ''
+    });
 
     const fetchScheduleDetail = async () => {
         try {
             const response = await ScheduleService.getScheduleDetail(scheduleId, classId);
             const detailData = response.data?.data;
-            setSchedule(detailData);
-            setMeetingTitle(detailData.meetingTitle);
-            setMeetingTime(detailData.meetingTime);
+
+            if (detailData) {
+                setSchedule(detailData);
+
+                // 기본값 설정
+                setMeetingTitle(detailData.meetingTitle || '');
+                setMeetingTime(detailData.meetingTime || '');
+
+                // 주소 정보 설정
+                const mainAddress = detailData.meetingPlace ? detailData.meetingPlace.split(' (')[0] : '';
+                const extraAddressPart = detailData.meetingPlace && detailData.meetingPlace.includes('(') ?
+                    `(${detailData.meetingPlace.split('(')[1]}` : '';
+
+                setAddressInfo({
+                    address: mainAddress,
+                    detailAddress: '',
+                    extraAddress: extraAddressPart,
+                    postcode: '',
+                    lat: detailData.lat || '',
+                    lng: detailData.lng || ''
+                });
+            } else {
+                console.error('일정 데이터가 없습니다:', response);
+                Alert('일정 정보를 찾을 수 없습니다.', '', '', () => navigate(`/classes/${classId}`));
+            }
         } catch (error) {
             console.error('일정 상세 조회 오류:', error);
             Alert(error.response?.data?.message || '일정 상세 조회에 실패했습니다.', '', '', () => navigate(`/classes/${classId}`));
@@ -30,22 +61,88 @@ const ScheduleDetail = () => {
         setMeetingTime(formattedDateTime);
     }, []);
 
+    const handleAddressSelect = (data) => {
+        setAddressInfo(data);
+    };
+
     const handleBackButton = () => {
+        // 변경 사항이 있는 경우 확인
+        if (isEditing && hasChanges()) {
+            if (window.confirm('변경 사항이 있습니다. 취소하시겠습니까?')) {
+                resetFormToOriginal();
+                setIsEditing(false);
+            }
+            return;
+        }
+
         // 수정 모드가 아닐 때만 클래스 페이지로 이동
         navigate(`/classes/${classId}`);
     };
 
-    const handleEditSubmit = async () => {
-        // 수정 모드로 전환시 초기 값 설정
-        const initialTitle = schedule.meetingTitle;
-        const initialTime = schedule.meetingTime;
+    // 변경 사항이 있는지 확인하는 함수
+    const hasChanges = () => {
+        if (!schedule) return false;
 
-        // 값이 변경되었는지 확인
-        if (meetingTitle === initialTitle && meetingTime === initialTime) {
-            Alert("변경된 내용이 없습니다.");
-            return;
+        const initialTitle = schedule.meetingTitle || '';
+        const initialTime = schedule.meetingTime || '';
+        const initialPlace = schedule.meetingPlace || '';
+        const initialLat = parseFloat(schedule.lat) || '';
+        const initialLng = parseFloat(schedule.lng) || '';
+
+        // 현재 상태의 주소 정보 계산
+        const currentPlace = addressInfo.address ?
+            `${addressInfo.address} ${addressInfo.detailAddress || ''}`.trim() :
+            '';
+        const currentLat = parseFloat(addressInfo.lat) || '';
+        const currentLng = parseFloat(addressInfo.lng) || '';
+
+        return meetingTitle !== initialTitle ||
+            meetingTime !== initialTime ||
+            currentPlace !== initialPlace ||
+            currentLat !== initialLat ||
+            currentLng !== initialLng;
+    };
+
+    // 폼을 원래 값으로 리셋
+    const resetFormToOriginal = () => {
+        if (!schedule) return;
+
+        setMeetingTitle(schedule.meetingTitle || '');
+        setMeetingTime(schedule.meetingTime || '');
+
+        const mainAddress = schedule.meetingPlace ? schedule.meetingPlace.split(' (')[0] : '';
+        const extraAddressPart = schedule.meetingPlace && schedule.meetingPlace.includes('(') ?
+            `(${schedule.meetingPlace.split('(')[1]}` : '';
+
+        setAddressInfo({
+            address: mainAddress,
+            detailAddress: '',
+            extraAddress: extraAddressPart,
+            postcode: '',
+            lat: schedule.lat || '',
+            lng: schedule.lng || ''
+        });
+    };
+
+    // 편집 모드 토글 핸들러
+    const toggleEditMode = () => {
+        if (isEditing && hasChanges()) {
+            // 변경 사항이 있는데 취소를 누른 경우
+            if (window.confirm('변경 사항이 있습니다. 취소하시겠습니까?')) {
+                resetFormToOriginal();
+                setIsEditing(false);
+            }
+        } else {
+            // 편집 모드로 들어가거나, 변경 사항 없이 취소하는 경우
+            setIsEditing(!isEditing);
+            if (!isEditing) {
+                // 편집 모드로 들어갈 때 현재 값으로 초기화
+                resetFormToOriginal();
+            }
         }
+    };
 
+    const handleEditSubmit = async () => {
         if (!meetingTitle.trim()) {
             Alert("일정 제목을 입력해주세요.");
             return;
@@ -56,9 +153,48 @@ const ScheduleDetail = () => {
             return;
         }
 
+        // 변경된 내용이 없는 경우 체크
+        if (!hasChanges()) {
+            Alert("변경된 내용이 없습니다.");
+            return;
+        }
+
+        // 주소 정보 생성
+        const meetingPlace = addressInfo.address ?
+            `${addressInfo.address} ${addressInfo.detailAddress || ''}`.trim() :
+            '';
+
+        // 주소가 변경되지 않았다면 기존 위치 정보 사용
+        let finalLat, finalLng;
+
+        if (addressInfo.address) {
+            // 새 주소를 입력한 경우 addressInfo의 lat/lng 사용
+            finalLat = parseFloat(addressInfo.lat);
+            finalLng = parseFloat(addressInfo.lng);
+
+            // 새 주소는 있는데 좌표가 없는 경우 (주소 검색은 했지만 좌표를 못 가져온 경우)
+            if (isNaN(finalLat) || isNaN(finalLng)) {
+                Alert("유효한 위치 정보가 필요합니다. 주소를 다시 검색해주세요.");
+                return;
+            }
+        } else {
+            // 주소를 변경하지 않은 경우 기존 좌표 사용
+            finalLat = parseFloat(schedule.lat);
+            finalLng = parseFloat(schedule.lng);
+
+            // 기존 좌표도 유효하지 않은 경우
+            if (isNaN(finalLat) || isNaN(finalLng)) {
+                Alert("유효한 위치 정보가 필요합니다. 주소를 검색해주세요.");
+                return;
+            }
+        }
+
         const body = {
             meetingTitle,
             meetingTime,
+            meetingPlace: meetingPlace || schedule.meetingPlace, // 새 주소가 없으면 기존 주소 사용
+            lat: finalLat || 37.5665, // 서울 중심부 좌표를 기본값으로 설정
+            lng: finalLng || 126.9780 // 서울 중심부 좌표를 기본값으로 설정
         };
 
         try {
@@ -86,6 +222,10 @@ const ScheduleDetail = () => {
     };
 
     const handleDelete = async () => {
+        if (!window.confirm('정말로 이 일정을 삭제하시겠습니까?')) {
+            return;
+        }
+
         try {
             const response = await ScheduleService.deleteSchedulesLists(scheduleId, classId);
             if (response.status === 200) {
@@ -105,6 +245,7 @@ const ScheduleDetail = () => {
         fetchScheduleDetail();
     }, [scheduleId, classId]);
 
+    // 데이터가 없는 경우 로딩 UI 표시
     if (!schedule) {
         return <div className="loading">로딩 중...</div>;
     }
@@ -119,7 +260,7 @@ const ScheduleDetail = () => {
                             뒤로 가기
                         </button>
                     )}
-                    <button className="custom-button" onClick={() => setIsEditing(!isEditing)}>
+                    <button className="custom-button" onClick={toggleEditMode}>
                         {isEditing ? '수정 취소' : '수정'}
                     </button>
                     <button className="custom-button warning" onClick={handleDelete}>
@@ -147,6 +288,15 @@ const ScheduleDetail = () => {
                                 initialDateTime={meetingTime}
                             />
                         </div>
+                        <div className="form-group">
+                            <label>모임 장소:</label>
+                            <Address
+                                onAddressSelect={handleAddressSelect}
+                                initialAddress={addressInfo.address || ''}
+                                initialLat={addressInfo.lat || ''}
+                                initialLng={addressInfo.lng || ''}
+                            />
+                        </div>
                         <button className="custom-button submit" onClick={handleEditSubmit}>
                             저장하기
                         </button>
@@ -155,7 +305,16 @@ const ScheduleDetail = () => {
                     <div className="schedule-info">
                         <h3>{schedule.meetingTitle}</h3>
                         <p className="meeting-time">{schedule.meetingTime}</p>
-                        {/* 추가적인 일정 정보가 있다면 여기에 표시 */}
+                        {schedule.meetingPlace && (
+                            <p className="meeting-place">장소: {schedule.meetingPlace}</p>
+                        )}
+                        {/* 위도/경도 정보는 필요하다면 여기에 추가 */}
+                        {(schedule.lat && schedule.lng) && (
+                            <div className="map-container">
+                                {/* 여기에 카카오맵 미니뷰를 추가할 수 있습니다 */}
+                                <p>위치 정보: {schedule.lat}, {schedule.lng}</p>
+                            </div>
+                        )}
                     </div>
                 )}
             </div>

--- a/frontend/src/services/SheduleService.jsx
+++ b/frontend/src/services/SheduleService.jsx
@@ -31,9 +31,13 @@ const postSchedulesLists = async (body) => {
 
 // 일정 수정
 const putSchedulesLists = async (scheduleId, classId, body) => {
-	const response = await axiosInstance.put(`${Project.API_URL}/schedules/${scheduleId}/classes/${classId}`, body, {
+	const response = await axiosInstance.put(
+		`${Project.API_URL}/schedules/${scheduleId}/classes/${classId}`,
+		body,
+		{
 		withCredentials: true,
-	});
+		}
+	);
 	return response;
 };
 


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [x] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#30  
  <br/>

## 🔎 작업 내용
### [Back - End]
#### 도메인
- SchedulesEntity에 meetingPlace(모임 장소), lat(위도), lng(경도) 속성 추가
- SchedulesService 일정 생성, 수정 함수의 null 체크에 위도와 경도 검사를 추가
#### global
- BaseInitData에 createScheduleData 함수에서 모임 장소, 경도, 위도를 추가(샘플 데이터에 모임 장소 정보가 없어서 Column not be null 에러 발생했었기 때문)
#### resources
- DB 마이그레이션이 필요(SchedulesEntity 속성 추가)하기 때문에 JPA/Hibernate의 ddl-auto설정을 create로 설정해뒀습니다.

### [Front - End]
#### components
- Address.jsx의 props에 초기값 추가 및 useEffect로 초기화 코드 추가했습니다.
#### pages
- Class.jsx, ScheduleDetail.jsx의 일정 생성, 수정 함수에 parseFloat() 함수를 사용하여 카카오맵 api에서 String타입으로 받아오던 위도, 경도 데이터를 double형태로 변환하였습니다.

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>