### PR TITLE
[FEAT] : 위치기반 서비스 FE, BE 구현

### DIFF
--- a/backend/src/main/java/z9/hobby/domain/kakaoMap/controller/KakaoMapController.java
+++ b/backend/src/main/java/z9/hobby/domain/kakaoMap/controller/KakaoMapController.java
@@ -1,0 +1,47 @@
+package z9.hobby.domain.kakaoMap.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import z9.hobby.domain.kakaoMap.dto.KakaoMapDto;
+import z9.hobby.domain.kakaoMap.service.KakaoMapService;
+import z9.hobby.global.response.BaseResponse;
+import z9.hobby.global.response.SuccessCode;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/kakaomap")
+@Tag(name = "KakaoMap Controller", description = "카카오맵 컨트롤러")
+@SecurityRequirement(name = "bearerAuth")
+public class KakaoMapController {
+    private final KakaoMapService kakaoMapService;
+
+    @GetMapping
+    @Operation(summary = "지도내에 해당하는 모임 일정 조회", description = "사용자가 지정한 관심사 혹은 전체 모임 일정을 조회합니다.")
+    public BaseResponse<List<KakaoMapDto.SchedulesLocationData>> getLocationInfo(
+            @RequestParam("filterType") String filterType,
+            @RequestParam("bottomLeftLat") double bottomLeftLat,
+            @RequestParam("bottomLeftLng") double bottomLeftLng,
+            @RequestParam("topRightLat") double topRightLat,
+            @RequestParam("topRightLng") double topRightLng,
+            Principal principal
+    ) {
+        Long userId = null;
+        if (principal != null) {
+            userId = Long.parseLong(principal.getName());
+        }
+
+        List<KakaoMapDto.SchedulesLocationData> locationData =
+                kakaoMapService.getLatLngInfo(filterType, bottomLeftLat, bottomLeftLng, topRightLat, topRightLng, userId);
+
+        return BaseResponse.Companion.ok(SuccessCode.SUCCESS, locationData);
+    }
+}

--- a/backend/src/main/java/z9/hobby/domain/kakaoMap/dto/KakaoMapDto.java
+++ b/backend/src/main/java/z9/hobby/domain/kakaoMap/dto/KakaoMapDto.java
@@ -1,0 +1,36 @@
+package z9.hobby.domain.kakaoMap.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import z9.hobby.domain.classes.entity.ClassEntity;
+import z9.hobby.model.schedules.SchedulesEntity;
+
+public class KakaoMapDto {
+
+    @Getter
+    @AllArgsConstructor
+    public static class SchedulesLocationData {
+        private final Long id;
+        private final String classTitle;
+        private final String scheduleTitle;
+        private final String favorite;
+        private final String date;
+        private final Double lat;
+        private final Double lng;
+
+        public static SchedulesLocationData from(
+                ClassEntity classEntity,
+                SchedulesEntity schedulesEntity
+        ) {
+            return new SchedulesLocationData(
+                    classEntity.getId(),
+                    classEntity.getName(),
+                    schedulesEntity.getMeetingTitle(),
+                    classEntity.getFavorite(),
+                    schedulesEntity.getMeetingTime(),
+                    schedulesEntity.getLat(),
+                    schedulesEntity.getLng()
+            );
+        }
+    }
+}

--- a/backend/src/main/java/z9/hobby/domain/kakaoMap/service/KakaoMapService.java
+++ b/backend/src/main/java/z9/hobby/domain/kakaoMap/service/KakaoMapService.java
@@ -1,0 +1,50 @@
+package z9.hobby.domain.kakaoMap.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import z9.hobby.domain.kakaoMap.dto.KakaoMapDto;
+import z9.hobby.global.exception.CustomException;
+import z9.hobby.global.response.ErrorCode;
+import z9.hobby.model.schedules.SchedulesEntity;
+import z9.hobby.model.schedules.SchedulesRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoMapService {
+    private final SchedulesRepository schedulesRepository;
+
+    @Transactional(readOnly = true)
+    public List<KakaoMapDto.SchedulesLocationData> getLatLngInfo(
+            String filterType,
+            double bottomLeftLat,
+            double bottomLeftLng,
+            double topRightLat,
+            double topRightLng,
+            Long userId
+    ) {
+        if (filterType == null) {
+            filterType = (userId != null) ? "FAVORITE" : "ALL";
+        }
+
+        List<SchedulesEntity> locationData;
+
+        if (filterType.equals("FAVORITE") && userId != null) {
+            locationData = schedulesRepository.findFavoriteSchedulesByUserId(userId, bottomLeftLat, bottomLeftLng, topRightLat, topRightLng);
+        } else {
+            locationData = schedulesRepository.findByLatLng(bottomLeftLat, bottomLeftLng, topRightLat, topRightLng);
+        }
+
+        // 일정이 없는경우
+        if (locationData.isEmpty()) {
+            throw new CustomException(ErrorCode.SCHEDULE_NOT_FOUND);
+        }
+
+        return locationData.stream()
+                .map(schedule -> KakaoMapDto.SchedulesLocationData.from(schedule.getClasses(), schedule))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/z9/hobby/model/schedules/SchedulesRepository.kt
+++ b/backend/src/main/java/z9/hobby/model/schedules/SchedulesRepository.kt
@@ -24,4 +24,33 @@ interface SchedulesRepository : JpaRepository<SchedulesEntity, Long> {
                 "ORDER BY s.meetingTime DESC")
     )
     fun findUserSchedulesInfoByUserId(@Param("userId") userId: Long): List<SchedulesEntity>
+
+    @Query(
+        ("SELECT s FROM SchedulesEntity s " +
+                "WHERE s.lat BETWEEN :bottomLeftLat AND :topRightLat " +
+                "AND s.lng BETWEEN LEAST(:bottomLeftLng, :topRightLng) AND GREATEST(:bottomLeftLng, :topRightLng)")
+    )
+    fun findByLatLng(
+        @Param("bottomLeftLat") bottomLeftLat: Double,
+        @Param("bottomLeftLng") bottomLeftLng: Double,
+        @Param("topRightLat") topRightLat: Double,
+        @Param("topRightLng") topRightLng: Double
+    ): List<SchedulesEntity>
+
+    @Query(
+        "SELECT s FROM SchedulesEntity s JOIN FETCH s.classes c " +
+                "WHERE s.lat BETWEEN :bottomLeftLat AND :topRightLat " +
+                "AND s.lng BETWEEN LEAST(:bottomLeftLng, :topRightLng) AND GREATEST(:bottomLeftLng, :topRightLng) " +
+                "AND c.favorite IN (" +
+                "    SELECT f.name FROM FavoriteEntity f, UserFavorite uf " +
+                "    WHERE uf.favorite.id = f.id AND uf.user.id = :userId" +
+                ")"
+    )
+    fun findFavoriteSchedulesByUserId(
+        @Param("userId") userId: Long,
+        @Param("bottomLeftLat") bottomLeftLat: Double,
+        @Param("bottomLeftLng") bottomLeftLng: Double,
+        @Param("topRightLat") topRightLat: Double,
+        @Param("topRightLng") topRightLng: Double
+    ): List<SchedulesEntity>
 }

--- a/frontend/src/components/CustomMap/CustomMap.css
+++ b/frontend/src/components/CustomMap/CustomMap.css
@@ -1,6 +1,21 @@
+.map-container {
+  position: relative;
+}
+
+.filter-container {
+  display: flex;
+  flex-flow: row-reverse;
+  margin-bottom: 10px;
+}
+
+.filter-container .filter-select {
+  padding: 6px;
+  border: 1px solid #a7a7a7;
+}
+
 .map-wrap {
   width: 100%;
-  height: 1000px;
+  height: 500px;
   border-radius: 10px;
 }
 
@@ -66,4 +81,40 @@
 
 .custom-overlay button:hover {
   background: #ff3b3b;
+}
+
+.btn-map-wrap {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+}
+
+.btn-map-wrap button {
+  margin-left: 8px;
+  padding: 8px 12px;
+  border: none;
+  border-radius: 4px;
+  background-color: white;
+  box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.9);
+  cursor: pointer;
+}
+
+.btn-map-wrap button:hover {
+  background-color: #f8f8f8;
+}
+
+.map-wrap button.enter {
+  margin-right: 3px;
+  background-color: var(--text-primary);
+}
+
+.map-wrap button.enter:hover {
+  background-color: var(--text-success);
+}
+
+.btn-map-wrap button.btn-location {
+  padding: 6px 10px;
 }

--- a/frontend/src/components/CustomMap/CustomMap.jsx
+++ b/frontend/src/components/CustomMap/CustomMap.jsx
@@ -1,41 +1,202 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Map, MapMarker, MarkerClusterer } from "react-kakao-maps-sdk";
 import { useUserLocation } from "src/hooks/userLocation";
+import { KakaoMapService } from 'src/services/KakaoMapService';
 
 import MarkerModal from "./MarkerModal";
 import SkeletonKakaoMap from "./SkeletonKakaoMap";
 import "./CustomMap.css";
 
-function CustomMap({ data }) {
+function CustomMap() {
   const { location, errorMessage } = useUserLocation();
   const [selectedMarker, setSelectedMarker] = useState(null);
+  const [mapCenter, setMapCenter] = useState(null);
+  const [mapLevel, setMapLevel] = useState(5); // 현재 줌 레벨 상태
+  const [locations, setLocations] = useState([]); // API에서 받아온 데이터 저장
+  const mapRef = useRef(null); // Map 컴포넌트 ref
+  const debounceTimer = useRef(null); // 디바운스 타이머
+  const [forceUpdate, setForceUpdate] = useState(0); // 강제 리렌더링을 위한 상태
+  const [isMapLoaded, setIsMapLoaded] = useState(false); // 지도 로딩 상태 추가
+  const initialLoadDone = useRef(false); // 초기 데이터 로드 여부 추적
+  const currentLevelRef = useRef(5); // 현재 맵 레벨을 ref로 추적
+  const [filterType, setFilterType] = useState("FAVORITE"); // 필터 타입 상태 추가
+
+  // 최초 location 업데이트 시 mapCenter를 설정합니다.
+  useEffect(() => {
+    if (location && !mapCenter) {
+      setMapCenter(location);
+    }
+  }, [location, mapCenter]);
+
+  // 첫 로드에만 데이터 불러오기
+  useEffect(() => {
+    if (mapCenter && isMapLoaded && mapRef.current && !initialLoadDone.current) {
+      handleSearch();
+      initialLoadDone.current = true; // 초기 로드 완료 표시
+    }
+  }, [mapCenter, isMapLoaded]);
+
+  // 지도의 중심 변경 시 디바운싱을 적용하여 상태 업데이트 (위치 추적만)
+  const handleCenterChanged = (map) => {
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+    }
+    debounceTimer.current = setTimeout(() => {
+      const center = map.getCenter();
+      setMapCenter({
+        latitude: center.getLat(),
+        longitude: center.getLng(),
+      });
+    }, 300);
+  };
+
+  // 지도의 줌 레벨 변경 시 현재 레벨 저장
+  const handleZoomChanged = (map) => {
+    const level = map.getLevel();
+    currentLevelRef.current = level;
+    setMapLevel(level);
+  };
+
+  // 내 위치 버튼 클릭 시 현재 위치로 이동하고 줌 레벨 5로 설정
+  const moveToMyLocation = () => {
+    if (!location) return;
+    
+    if (mapRef.current && window.kakao && window.kakao.maps) {
+      const newCenter = new window.kakao.maps.LatLng(location.latitude, location.longitude);
+      mapRef.current.setCenter(newCenter);
+      mapRef.current.setLevel(5);
+      currentLevelRef.current = 5;
+      setMapLevel(5);
+    } else {
+      console.warn("Kakao Maps API가 로드되지 않았습니다.");
+    }
+    setMapCenter(location);
+  };
+
+  // 필터 타입 변경 핸들러
+  const handleFilterChange = (e) => {
+    setFilterType(e.target.value);
+  };
+
+  // 현재 지도 영역에 있는 데이터 검색 (버튼 클릭 또는 초기 로드시에만 실행)
+  const handleSearch = async () => {
+    if (mapRef.current && window.kakao && window.kakao.maps) {
+      // 현재 맵 레벨 저장
+      const currentLevel = mapRef.current.getLevel();
+      currentLevelRef.current = currentLevel;
+      setMapLevel(currentLevel);
+      
+      const bounds = mapRef.current.getBounds();
+      const northEast = bounds.getNorthEast();
+      const southWest = bounds.getSouthWest();
+  
+      const bottomLeft = { 
+        lat: southWest.getLat(), 
+        lng: southWest.getLng() 
+      };
+      const topRight = { 
+        lat: northEast.getLat(), 
+        lng: northEast.getLng() 
+      };
+  
+      try {
+        const response = await KakaoMapService.getLocationInfo(filterType, bottomLeft, topRight);
+        setLocations(response.data.data);
+        
+        // 마커가 즉시 표시되도록 강제 리렌더링 트리거
+        setForceUpdate(prev => prev + 1);
+      } catch (error) {
+        console.error("API 호출 중 오류 발생:", error);
+        setLocations([]);
+      }
+    }
+  };
 
   if (errorMessage) {
     return <span className="error-icon">⚠️{errorMessage}</span>;
   }
 
-  if (!location) {
+  if (!mapCenter) {
     return <SkeletonKakaoMap />;
   }
-
+  
   return (
-    <Map
-      className="map-wrap"
-      center={{ lat: location.latitude, lng: location.longitude }}
-      level={3}
-    >
-      <MarkerClusterer averageCenter={true} minLevel={7}>
-        {data.LOCATION.map((loc) => (
+    <div className="map-container">
+      <div className="filter-container">
+        <select 
+          value={filterType} 
+          onChange={handleFilterChange}
+          className="filter-select"
+        >
+          <option value="FAVORITE">관심사</option>
+          <option value="ALL">전체</option>
+        </select>
+      </div>
+      <Map
+        className="map-wrap"
+        center={{ lat: mapCenter.latitude, lng: mapCenter.longitude }}
+        level={currentLevelRef.current} // ref에서 현재 레벨 사용
+        onCenterChanged={handleCenterChanged}
+        onZoomChanged={handleZoomChanged} // 줌 변경 이벤트 핸들러 추가
+        onCreate={(map) => {
+          mapRef.current = map;
+          setIsMapLoaded(true);
+        }}
+        ref={mapRef}
+        key={`map-${forceUpdate}`} // forceUpdate가 변경될 때 Map 컴포넌트를 리렌더링
+      >
+        {/* 내 현재 위치 마커 */}
+        {location && (
           <MapMarker
-            key={loc.id}
-            position={{ lat: loc.lat, lng: loc.lng }}
-            title={loc.name}
-            onClick={() => setSelectedMarker(loc)}
+            position={{ lat: location.latitude, lng: location.longitude }}
+            title="내 위치"
+            image={{
+              src: `data:image/svg+xml;utf8,${encodeURIComponent(
+                `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+                  <!-- 중앙 빨간색 원 -->
+                  <circle cx="16" cy="16" r="8" fill="red" />
+                  <!-- 바깥 빨간 테두리 -->
+                  <circle cx="16" cy="16" r="12" fill="none" stroke="red" strokeWidth="2" />
+                </svg>`
+              )}`,
+              size: { width: 16, height: 16 }
+            }}
           />
-        ))}
-      </MarkerClusterer>
-      {selectedMarker && <MarkerModal mark={selectedMarker} />}
-    </Map>
+        )}
+        
+        {/* 위치 데이터 마커 */}
+        <MarkerClusterer 
+          averageCenter={true} 
+          minLevel={7}
+          key={`cluster-${forceUpdate}`} // forceUpdate가 변경될 때 MarkerClusterer도 리렌더링
+        >
+          {locations.map((loc, index) => (
+            <MapMarker
+              key={loc.id ? `${loc.id}-${index}` : `marker-${index}`}
+              position={{ lat: loc.lat, lng: loc.lng }}
+              title={loc.name}
+              onClick={() => setSelectedMarker(loc)}
+            />
+          ))}
+        </MarkerClusterer>
+        
+        {/* 내 위치 이동 버튼 */}
+        <div className="btn-map-wrap">
+          <button onClick={handleSearch}>
+            현 위치 검색
+          </button>
+          <button className="btn-location" onClick={moveToMyLocation}>
+            <svg width="16" height="16" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="32" cy="32" r="20" fill="none" stroke="#000" strokeWidth="6"/>
+              <circle cx="32" cy="32" r="10" fill="#000"/>
+              <circle cx="32" cy="32" r="4" fill="#fff"/>
+              <path fill="none" stroke="#000" strokeWidth="6" d="M32 2v10M32 52v10M2 32h10M52 32h10"/>
+            </svg>
+          </button>
+        </div>
+        {selectedMarker && <MarkerModal mark={selectedMarker} onClose={() => setSelectedMarker(null)} />}
+      </Map>
+    </div>
   );
 }
 

--- a/frontend/src/components/CustomMap/MarkerModal.jsx
+++ b/frontend/src/components/CustomMap/MarkerModal.jsx
@@ -1,12 +1,76 @@
 import { CustomOverlayMap } from "react-kakao-maps-sdk";
+import { useNavigate } from "react-router-dom";
+import Alert from "src/components/alert/Alert";
+import { ClassService } from 'src/services/ClassService';
 
-const MarkerModal = ({ mark }) => {
+const MarkerModal = ({ mark, onClose }) => {
+  const navigate = useNavigate();
+
+  const result = (id) => {
+    navigate(`/classes/${id}`);
+  }
+
+  const handlerJoin = async (id) => {
+    const isMember = await checkMember(id);
+    const isBlackList = await checkBlackList(id);
+    if (isBlackList) {
+      Alert("강퇴당한 회원은 재가입 하실 수 없습니다.")
+    } else if (isMember) {
+      result(id);
+    } else {
+      Alert("가입된 회원이 아닙니다. <br>가입 하시겠습니까?", "취소", "가입", (e) => {if (e) {joinClass(id)}});
+    }
+  }
+
+  // 모임 가입 확인
+  const checkMember = async (id) => {
+    try {
+      const response = await ClassService.checkMember(id);
+      const checkData = response.data;
+      const getData = checkData?.data || [];
+      const isMember = getData.member;
+      return isMember;
+    } catch (error) {
+      console.error("checkMember:", error);
+    }
+  };
+
+  // 블랙리스트 확인
+  const checkBlackList = async (id) => {
+    try {
+      const response = await ClassService.checkBlackList(id);
+      const checkData = response.data;
+      const getData = checkData?.data || [];
+      const isBlackList = getData.blackListed;
+      return isBlackList;
+    } catch (error) {
+      console.error("checkBlackList:", error);
+    }
+  };
+
+  // 모임 가입
+  const joinClass = async (id) => {
+    try {
+      const response = await ClassService.joinClass(id);
+      if (response.status === 200) {
+        Alert("모임에 가입되었습니다.", "", "", () => result(id));
+      } else {
+        Alert("가입에 실패했습니다");
+      }
+    } catch (error) {
+      console.error("join error:", error);
+      Alert(error.response.data.message);
+    }
+  }
+
   return (
     <CustomOverlayMap position={{ lat: mark.lat, lng: mark.lng }} yAnchor={1.5}>
-      <div className='custom-overlay'>
-        <h4>{mark.name}</h4>
-        <p>{mark.description}</p>
-        <button onClick={() => mark(null)}>Close</button>
+      <div className="custom-overlay">
+        <h4>{mark.classTitle}</h4>
+        <p>날짜: {mark.date}</p>
+        <p>관심사: {mark.favorite}</p>
+        <button className='enter' onClick={() => handlerJoin(mark.id)}>입장</button>
+        <button onClick={onClose}>Close</button>
       </div>
     </CustomOverlayMap>
   );

--- a/frontend/src/components/header/Header.jsx
+++ b/frontend/src/components/header/Header.jsx
@@ -27,10 +27,15 @@ const Header = () => {
     navigate(isLogin?'/mypage':"/join");
   }
 
+  const handleKakaoMap = () => {
+    navigate("/kakaomap");
+  }
+
 	return (
     <header id="header">
       <Logo />
       <nav className='nav-wrap'>
+        <button onClick={handleKakaoMap}>지도</button>
         <button onClick={handleLoginOrLogout}>{!isLogin ? "로그인" : "로그아웃"}</button>
         <button onClick={handleSignupOrMypage}>{!isLogin ? "회원가입" : "마이페이지"}</button>
       </nav>

--- a/frontend/src/pages/kakaoMap/KakaoMap.jsx
+++ b/frontend/src/pages/kakaoMap/KakaoMap.jsx
@@ -1,12 +1,10 @@
 import React from "react";
-import { dummy } from "src/components/CustomMap/dummy";
 import CustomMap from "src/components/CustomMap/CustomMap";
 
 const KakaoMap = () => {
-  const DUMMY = dummy;
   return (
     <div>
-      <CustomMap data={DUMMY} />
+      <CustomMap />
     </div>
   );
 };

--- a/frontend/src/services/KakaoMapService.jsx
+++ b/frontend/src/services/KakaoMapService.jsx
@@ -1,0 +1,19 @@
+import axiosInstance from "src/constants/axiosInstance";
+import { Project } from "src/constants/project";
+
+const getLocationInfo = async (filterType, bottomLeft, topRight) => {
+    const response = await axiosInstance
+    .get(`${Project.API_URL}/kakaomap?filterType=${filterType}&bottomLeftLat=${bottomLeft.lat}&bottomLeftLng=${bottomLeft.lng}&topRightLat=${topRight.lat}&topRightLng=${topRight.lng}`, 
+      {
+        withCredentials: true,
+      }
+    );
+    return response;
+  };
+
+
+const KakaoMapService = {
+    getLocationInfo,
+}
+
+export { KakaoMapService };


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [x] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#33 
  <br/>

## 🔎 작업 내용
FE
- 카카오 맵 api를 활용, 현재 보이는 지역에 존재하는 모임 일정 조회.
  - 로그인 시 회원이 설정한 관심사에 해당하는 모임의 일정만 조회하거나 전체일정 조회.
- 현재 위치로 이동

BE
- 현재 지도의 경계좌표를 전달받고, schedulesRepository에서 해당 경계좌표 내부에 존재하는 모임 일정을 조회하는 로직 추가

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>